### PR TITLE
reload events handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,4 +311,5 @@ This section will list out all the available methods and functionality in the li
 
 ```ts
 .editBotsStatus(status, name, type)
+updateEventHandlers(eventHandlers)
 ```

--- a/module/client.ts
+++ b/module/client.ts
@@ -52,5 +52,5 @@ export const updateChannelCache = (key: string, value: Channel) => {
 };
 
 export function updateEventHandlers(newEventHandlers: EventHandlers) {
-  eventHandlers = newEventHandlers
+  eventHandlers = newEventHandlers;
 }

--- a/module/client.ts
+++ b/module/client.ts
@@ -50,3 +50,7 @@ export default createClient;
 export const updateChannelCache = (key: string, value: Channel) => {
   cache.channels.set(key, value);
 };
+
+export function updateEventHandlers(newEventHandlers: EventHandlers) {
+  eventHandlers = newEventHandlers
+}


### PR DESCRIPTION
This PR adds the ability to update the event handler's live without having to restart the entire bot. Simple call the `updateEventHandlers` function and pass in a new eventHandlers object similar to the one passed when starting the bot and it will update. Very useful for fixing tiny mistakes without having to reboot.