### PR TITLE
V3: Refactor export type into interfaces + enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This section will list out all the available methods and functionality in the li
 - mention
 - raw
 ```ts
+- .hasPermission(id, permissions)
 - .getMessage(id)
 - .getMessages(options)
 - .getPins()
@@ -222,7 +223,9 @@ This section will list out all the available methods and functionality in the li
 - premiumSince
 - tag
 - mention
+- guildID
 ```ts
+- .guild()
 - .avatarURL(size, format)
 - .addRole(roleID, reason)
 - .removeRole(roleID, reason)

--- a/module/shardingManager.ts
+++ b/module/shardingManager.ts
@@ -190,9 +190,7 @@ function handleDiscordPayload(data: DiscordPayload) {
         guild.memberCount = memberCount;
         const member = createMember(
           options,
-          guild.id,
-          [...guild.roles.values()].map((role) => role.raw),
-          guild.ownerID,
+          guild,
         );
         guild.members.set(options.user.id, member);
         cache.users.set(options.user.id, createUser(member.user));
@@ -232,9 +230,7 @@ function handleDiscordPayload(data: DiscordPayload) {
         };
         const member = createMember(
           newMemberData,
-          options.guild_id,
-          [...guild.roles.values()].map((r) => r.raw),
-          guild.ownerID,
+          guild,
         );
         guild.members.set(options.user.id, member);
         cache.users.set(options.user.id, createUser(member.user));
@@ -274,9 +270,7 @@ function handleDiscordPayload(data: DiscordPayload) {
             member.user.id,
             createMember(
               member,
-              options.guild_id,
-              [...guild.roles.values()].map((r) => r.raw),
-              guild.ownerID,
+              guild,
             ),
           );
           cache.users.set(member.user.id, createUser(member.user));
@@ -341,9 +335,7 @@ function handleDiscordPayload(data: DiscordPayload) {
             options.author.id,
             createMember(
               { ...options.member, user: options.author },
-              options.guild_id,
-              [...guild.roles.values()].map((r) => r.raw),
-              guild.ownerID,
+              guild,
             ),
           );
         }
@@ -418,9 +410,7 @@ function handleDiscordPayload(data: DiscordPayload) {
           if (guild) {
             const member = createMember(
               options.member,
-              options.guild_id,
-              [...guild.roles.values()].map((r) => r.raw),
-              guild.ownerID,
+              guild,
             );
             guild.members.set(
               options.member.user.id,

--- a/module/shardingManager.ts
+++ b/module/shardingManager.ts
@@ -330,7 +330,9 @@ function handleDiscordPayload(data: DiscordPayload) {
         const message = createMessage(options);
         // Cache the message
         cache.messages.set(options.id, message);
-        const guild = options.guild_id ? cache.guilds.get(options.guild_id) : undefined;
+        const guild = options.guild_id
+          ? cache.guilds.get(options.guild_id)
+          : undefined;
 
         if (options.member) {
           // If in a guild cache the author as a member
@@ -350,7 +352,10 @@ function handleDiscordPayload(data: DiscordPayload) {
           cache.users.set(mention.id, createUser(mention));
           // Cache the member if its a valid member
           if (mention.member) {
-            guild?.members.set(mention.id, createMember({ ...mention.member, user: mention }, guild))
+            guild?.members.set(
+              mention.id,
+              createMember({ ...mention.member, user: mention }, guild),
+            );
           }
         });
 

--- a/structures/channel.ts
+++ b/structures/channel.ts
@@ -51,6 +51,23 @@ export function createChannel(data: ChannelCreatePayload) {
     /** The mention of the channel */
     mention: `<#${data.id}>`,
 
+    /** Checks if a user id or a role id has permission in this channel */
+    hasPermission: function (id: string, permissions: Permissions[]) {
+      const overwrite = data.permission_overwrites?.find((perm) =>
+        perm.id === id
+      ) ||
+        data.permission_overwrites?.find((perm) => perm.id === channel.guildID);
+      if (!overwrite) return false;
+
+      return permissions.every((perm) => {
+        if (overwrite.deny & perm) return false;
+        if (overwrite.allow & perm) return true;
+        if (channel.guildID) {
+          return botHasPermission(channel.guildID, [perm]);
+        }
+        return false;
+      });
+    },
     /** Fetch a single message from the server. Requires VIEW_CHANNEL and READ_MESSAGE_HISTORY */
     getMessage: async (id: string) => {
       if (data.guild_id) {

--- a/structures/channel.ts
+++ b/structures/channel.ts
@@ -213,4 +213,4 @@ export function createChannel(data: ChannelCreatePayload) {
   return channel;
 }
 
-export type Channel = ReturnType<typeof createChannel>;
+export interface Channel extends ReturnType<typeof createChannel> {}

--- a/structures/guild.ts
+++ b/structures/guild.ts
@@ -15,7 +15,7 @@ import {
   FetchMembersOptions,
 } from "../types/guild.ts";
 import { createRole } from "./role.ts";
-import { createMember } from "./member.ts";
+import { createMember, Member } from "./member.ts";
 import { createChannel } from "./channel.ts";
 import {
   CreateChannelOptions,
@@ -70,11 +70,7 @@ export const createGuild = (data: CreateGuildPayload) => {
     /** When this guild was joined at. */
     joinedAt: Date.parse(data.joined_at),
     /** The users in this guild. */
-    members: new Map(
-      data.members.map((
-        m,
-      ) => [m.user.id, createMember(m, data.id, data.roles, data.owner_id)]),
-    ),
+    members: new Map<string, Member>(),
     /** The channels in the guild */
     channels: new Map(data.channels.map((c) => [c.id, createChannel(c)])),
     /** The presences of all the users in the guild. */
@@ -225,7 +221,7 @@ export const createGuild = (data: CreateGuildPayload) => {
 
       const roleData = role_data as RoleData;
       const role = createRole(roleData);
-      guild.roles.set(roleData.id, role);
+      // guild.roles.set(roleData.id, role);
       return role;
     },
     /** Edit a guild role. Requires the MANAGE_ROLES permission. */
@@ -473,7 +469,11 @@ export const createGuild = (data: CreateGuildPayload) => {
     },
   };
 
+  data.members.forEach((m) =>
+    guild.members.set(m.user.id, createMember(m, guild))
+  );
+
   return guild;
 };
 
-export type Guild = ReturnType<typeof createGuild>;
+export interface Guild extends ReturnType<typeof createGuild> {}

--- a/structures/guild.ts
+++ b/structures/guild.ts
@@ -221,7 +221,7 @@ export const createGuild = (data: CreateGuildPayload) => {
 
       const roleData = role_data as RoleData;
       const role = createRole(roleData);
-      // guild.roles.set(roleData.id, role);
+      guild.roles.set(roleData.id, role);
       return role;
     },
     /** Edit a guild role. Requires the MANAGE_ROLES permission. */

--- a/structures/member.ts
+++ b/structures/member.ts
@@ -3,7 +3,6 @@ import { formatImageURL } from "../utils/cdn.ts";
 import { MemberCreatePayload, EditMemberOptions } from "../types/member.ts";
 import { ImageSize, ImageFormats } from "../types/cdn.ts";
 import { Permission, Permissions } from "../types/permission.ts";
-import { RoleData } from "../types/role.ts";
 import {
   memberHasPermission,
   botHasPermission,
@@ -13,13 +12,9 @@ import {
 import { Errors } from "../types/errors.ts";
 import { RequestManager } from "../module/requestManager.ts";
 import { botID } from "../module/client.ts";
+import { Guild } from "./guild.ts";
 
-export const createMember = (
-  data: MemberCreatePayload,
-  guildID: string,
-  roleData: RoleData[],
-  ownerID: string,
-) => ({
+export const createMember = (data: MemberCreatePayload, guild: Guild) => ({
   ...data,
   /** The complete raw data from the member create payload */
   raw: data,
@@ -43,45 +38,45 @@ export const createMember = (
       : endpoints.USER_DEFAULT_AVATAR(Number(data.user.discriminator) % 5),
   /** Add a role to the member */
   addRole: (roleID: string, reason?: string) => {
-    const botsHighestRole = highestRole(guildID, botID);
+    const botsHighestRole = highestRole(guild.id, botID);
     if (
       botsHighestRole &&
-      !higherRolePosition(guildID, botsHighestRole.id, roleID)
+      !higherRolePosition(guild.id, botsHighestRole.id, roleID)
     ) {
       throw new Error(Errors.BOTS_HIGHEST_ROLE_TOO_LOW);
     }
 
-    if (!botHasPermission(guildID, [Permissions.MANAGE_ROLES])) {
+    if (!botHasPermission(guild.id, [Permissions.MANAGE_ROLES])) {
       throw new Error(Errors.MISSING_MANAGE_ROLES);
     }
 
     return RequestManager.put(
-      endpoints.GUILD_MEMBER_ROLE(guildID, data.user.id, roleID),
+      endpoints.GUILD_MEMBER_ROLE(guild.id, data.user.id, roleID),
       { reason },
     );
   },
   /** Remove a role from the member */
   removeRole: (roleID: string, reason?: string) => {
-    const botsHighestRole = highestRole(guildID, botID);
+    const botsHighestRole = highestRole(guild.id, botID);
     if (
       botsHighestRole &&
-      !higherRolePosition(guildID, botsHighestRole.id, roleID)
+      !higherRolePosition(guild.id, botsHighestRole.id, roleID)
     ) {
       throw new Error(Errors.BOTS_HIGHEST_ROLE_TOO_LOW);
     }
 
-    if (!botHasPermission(guildID, [Permissions.MANAGE_ROLES])) {
+    if (!botHasPermission(guild.id, [Permissions.MANAGE_ROLES])) {
       throw new Error(Errors.MISSING_MANAGE_ROLES);
     }
     return RequestManager.delete(
-      endpoints.GUILD_MEMBER_ROLE(guildID, data.user.id, roleID),
+      endpoints.GUILD_MEMBER_ROLE(guild.id, data.user.id, roleID),
       { reason },
     );
   },
   /** Kick a member from the server */
   kick: (reason?: string) => {
-    const botsHighestRole = highestRole(guildID, botID);
-    const membersHighestRole = highestRole(guildID, data.user.id);
+    const botsHighestRole = highestRole(guild.id, botID);
+    const membersHighestRole = highestRole(guild.id, data.user.id);
     if (
       botsHighestRole && membersHighestRole &&
       botsHighestRole.position <= membersHighestRole.position
@@ -89,11 +84,11 @@ export const createMember = (
       throw new Error(Errors.BOTS_HIGHEST_ROLE_TOO_LOW);
     }
 
-    if (!botHasPermission(guildID, [Permissions.KICK_MEMBERS])) {
+    if (!botHasPermission(guild.id, [Permissions.KICK_MEMBERS])) {
       throw new Error(Errors.MISSING_KICK_MEMBERS);
     }
     return RequestManager.delete(
-      endpoints.GUILD_MEMBER(guildID, data.user.id),
+      endpoints.GUILD_MEMBER(guild.id, data.user.id),
       { reason },
     );
   },
@@ -103,14 +98,14 @@ export const createMember = (
       if (options.nick.length > 32) {
         throw new Error(Errors.NICKNAMES_MAX_LENGTH);
       }
-      if (!botHasPermission(guildID, [Permissions.MANAGE_NICKNAMES])) {
+      if (!botHasPermission(guild.id, [Permissions.MANAGE_NICKNAMES])) {
         throw new Error(Errors.MISSING_MANAGE_NICKNAMES);
       }
     }
 
     if (
       options.roles &&
-      !botHasPermission(guildID, [Permissions.MANAGE_ROLES])
+      !botHasPermission(guild.id, [Permissions.MANAGE_ROLES])
     ) {
       throw new Error(Errors.MISSING_MANAGE_ROLES);
     }
@@ -118,7 +113,7 @@ export const createMember = (
     if (options.mute) {
       // TODO: This should check if the member is in a voice channel
       if (
-        !botHasPermission(guildID, [Permissions.MUTE_MEMBERS])
+        !botHasPermission(guild.id, [Permissions.MUTE_MEMBERS])
       ) {
         throw new Error(Errors.MISSING_MUTE_MEMBERS);
       }
@@ -126,7 +121,7 @@ export const createMember = (
 
     if (
       options.deaf &&
-      !botHasPermission(guildID, [Permissions.DEAFEN_MEMBERS])
+      !botHasPermission(guild.id, [Permissions.DEAFEN_MEMBERS])
     ) {
       throw new Error(Errors.MISSING_DEAFEN_MEMBERS);
     }
@@ -134,7 +129,7 @@ export const createMember = (
     // TODO: if channel id is provided check if the bot has CONNECT and MOVE in channel and current channel
 
     return RequestManager.patch(
-      endpoints.GUILD_MEMBER(guildID, data.user.id),
+      endpoints.GUILD_MEMBER(guild.id, data.user.id),
       options,
     );
   },
@@ -142,10 +137,11 @@ export const createMember = (
   hasPermissions: (permissions: Permission[]) => {
     return memberHasPermission(
       data.user.id,
-      ownerID,
-      roleData,
+      guild,
       data.roles,
       permissions,
     );
   },
 });
+
+export interface Member extends ReturnType<typeof createMember> {}

--- a/structures/member.ts
+++ b/structures/member.ts
@@ -13,6 +13,7 @@ import { Errors } from "../types/errors.ts";
 import { RequestManager } from "../module/requestManager.ts";
 import { botID } from "../module/client.ts";
 import { Guild } from "./guild.ts";
+import { cache } from "../utils/cache.ts";
 
 export const createMember = (data: MemberCreatePayload, guild: Guild) => ({
   ...data,
@@ -26,7 +27,11 @@ export const createMember = (data: MemberCreatePayload, guild: Guild) => ({
   tag: `${data.user.username}#${data.user.discriminator}`,
   /** The user mention with nickname if possible */
   mention: `<@!${data.user.id}>`,
+  /** The guild id where this member exists */
+  guildID: guild.id,
 
+  /** Gets the guild object from cache for this member. This is a method instead of a prop to preserve memory. */
+  guild: () => cache.guilds.get(guild.id)!,
   /** The users custom avatar or the default avatar */
   avatarURL: (size: ImageSize = 128, format?: ImageFormats) =>
     data.user.avatar

--- a/structures/message.ts
+++ b/structures/message.ts
@@ -160,4 +160,4 @@ export function createMessage(data: MessageCreateOptions) {
   };
 }
 
-export type Message = ReturnType<typeof createMessage>;
+export interface Message extends ReturnType<typeof createMessage> {}

--- a/structures/message.ts
+++ b/structures/message.ts
@@ -11,7 +11,7 @@ import { botID } from "../module/client.ts";
 import { cache } from "../utils/cache.ts";
 
 export function createMessage(data: MessageCreateOptions) {
-  return {
+  const message = {
     ...data,
     raw: data,
     channelID: data.channel_id,
@@ -19,11 +19,11 @@ export function createMessage(data: MessageCreateOptions) {
     mentionsEveryone: data.mentions_everyone,
     mentionRoles: data.mention_roles,
     mentionChannels: data.mention_channels,
-    mentions: data.mentions.map((user) => createUser(user)),
+    mentions: data.mentions.map((user) => cache.users.get(user.id)!),
     webhookID: data.webhook_id,
     messageReference: data.message_reference,
 
-    author: createUser({ ...data.author, avatar: data.author.avatar || "" }),
+    author: cache.users.get(data.author.id)!,
     timestamp: Date.parse(data.timestamp),
     editedTimestamp: data.edited_timestamp
       ? Date.parse(data.edited_timestamp)
@@ -32,13 +32,14 @@ export function createMessage(data: MessageCreateOptions) {
 
     /** Delete a message */
     delete: (reason?: string) => {
-      if (
-        data.guild_id &&
-        !botHasPermission(data.guild_id, [Permissions.MANAGE_MESSAGES])
-      ) {
-        throw new Error(Errors.MISSING_MANAGE_MESSAGES);
-      }
       if (data.author.id !== botID) {
+        // This needs to check the channels permission not the guild permission
+        if (
+          !message.guildID ||
+          !message.channel.hasPermission(botID, [Permissions.MANAGE_MESSAGES])
+        ) {
+          throw new Error(Errors.MISSING_MANAGE_MESSAGES);
+        }
       }
 
       return RequestManager.delete(
@@ -158,6 +159,8 @@ export function createMessage(data: MessageCreateOptions) {
       return createMessage(result as MessageCreateOptions);
     },
   };
+
+  return message;
 }
 
 export interface Message extends ReturnType<typeof createMessage> {}

--- a/structures/role.ts
+++ b/structures/role.ts
@@ -8,4 +8,4 @@ export const createRole = (data: RoleData) => ({
   mention: `<@&${data.id}>`,
 });
 
-export type Role = ReturnType<typeof createRole>;
+export interface Role extends ReturnType<typeof createRole> {}

--- a/structures/user.ts
+++ b/structures/user.ts
@@ -29,4 +29,4 @@ export const createUser = (data: UserPayload) => ({
       : endpoints.USER_DEFAULT_AVATAR(Number(data.discriminator) % 5),
 });
 
-export type User = ReturnType<typeof createUser>;
+export interface User extends ReturnType<typeof createUser> {}

--- a/types/member.ts
+++ b/types/member.ts
@@ -1,4 +1,3 @@
-import { createMember } from "../structures/member.ts";
 import { UserPayload } from "./guild.ts";
 
 export interface EditMemberOptions {
@@ -30,5 +29,3 @@ export interface MemberCreatePayload {
   /** Whether the user is muted in voice channels */
   mute: boolean;
 }
-
-export type Member = ReturnType<typeof createMember>;

--- a/types/message.ts
+++ b/types/message.ts
@@ -1,7 +1,8 @@
 import { ChannelType, UserPayload } from "./guild.ts";
 import { User } from "../structures/user.ts";
-import { Member, MemberCreatePayload } from "./member.ts";
+import { MemberCreatePayload } from "./member.ts";
 import { Channel } from "../structures/channel.ts";
+import { Member } from "../structures/member.ts";
 
 export interface MentionedUser extends User {
   member: Member;

--- a/types/options.ts
+++ b/types/options.ts
@@ -7,7 +7,6 @@ import {
   VoiceStateUpdatePayload,
 } from "./discord.ts";
 import { User } from "../structures/user.ts";
-import { Member } from "./member.ts";
 import { Role } from "../structures/role.ts";
 import { Message } from "../structures/message.ts";
 import {
@@ -19,6 +18,7 @@ import {
 } from "./message.ts";
 import { Channel } from "../structures/channel.ts";
 import { Guild } from "../structures/guild.ts";
+import { Member } from "../structures/member.ts";
 
 export interface Fulfilled_Client_Options {
   token: string;

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -1,25 +1,32 @@
 import { Permission, Permissions } from "../types/permission.ts";
-import { RoleData } from "../types/role.ts";
 import { cache } from "./cache.ts";
 import { botID } from "../module/client.ts";
 import { Role } from "../structures/role.ts";
+import { Guild } from "../structures/guild.ts";
 
 export function memberHasPermission(
   memberID: string,
-  ownerID: string,
-  roleData: RoleData[],
+  guild: Guild,
   memberRoleIDs: string[],
   permissions: Permission[],
 ) {
-  if (memberID === ownerID) return true;
+  if (memberID === guild.ownerID) return true;
 
-  const permissionBits = roleData
-    .filter((role) => memberRoleIDs.includes(role.id))
-    .reduce((bits, data) => {
-      bits |= data.permissions;
-
+  const permissionBits = memberRoleIDs.map((id) =>
+    guild.roles.get(id)?.permissions || 0
+  )
+    .reduce((bits, permissions) => {
+      bits |= permissions;
       return bits;
     }, 0);
+
+  // const permissionBits = [...guild.roles.values()]
+  //   .filter((role) => memberRoleIDs.includes(role.id))
+  //   .map((role) => role.permissions)
+  //   .reduce((bits, permissions) => {
+  //     bits |= permissions;
+  //     return bits;
+  //   }, 0);
 
   if (permissionBits & Permissions.ADMINISTRATOR) return true;
 


### PR DESCRIPTION
This PR adds some major refactors and user experience improvements to make your lives easier as developers. For example, simply passing the guild and member data to create a member isntead of calculating role data from a guild and passing 5 arguments. Now its just `createMember(memberDataFromDiscord, guild)` 🎉 

This PR also makes the usage of the library easier as you can see much better what the type of any variable instead of trying to understand the full object.
- Adds member.guildID
- Adds member.guild()
- Adds channel.hasPermission(id, permissions)
- Caches all users and members when mentioned
- fix: No longer create new users in createMessage instead get the user from cache which is done inside shardingManager when the payload is received

**Before**
![image](https://user-images.githubusercontent.com/23035000/82479389-4d447b80-9aa0-11ea-92b4-be6aea6a2013.png)

**Now:**
![image](https://user-images.githubusercontent.com/23035000/82479436-62b9a580-9aa0-11ea-861e-22ef5db0e635.png)

This changes the public api so requires a version bump.