### PR TITLE
Alternative sharding solution for smaller bots

### DIFF
--- a/module/basicShard.ts
+++ b/module/basicShard.ts
@@ -1,0 +1,203 @@
+import {
+  DiscordBotGatewayData,
+  GatewayOpcode,
+  ReadyPayload,
+} from "../types/discord.ts";
+import {
+  eventHandlers,
+  botGatewayData,
+  IdentifyPayload,
+} from "./client.ts";
+import { delay } from "https://deno.land/std@0.61.0/async/delay.ts";
+import {
+  connectWebSocket,
+  isWebSocketCloseEvent,
+  WebSocket,
+} from "https://deno.land/std@0.61.0/ws/mod.ts";
+import { DiscordHeartbeatPayload } from "../types/discord.ts";
+import { logRed } from "../utils/logger.ts";
+import { handleDiscordPayload } from "./shardingManager.ts";
+
+const basicShards = new Map<number, BasicShard>();
+
+export interface BasicShard {
+  id: number;
+  socket: WebSocket;
+  resumeInterval: number;
+  sessionID: string;
+  previousSequenceNumber: number | null;
+  needToResume: boolean;
+}
+
+export async function createBasicShard(
+  data: DiscordBotGatewayData,
+  identifyPayload: IdentifyPayload,
+  resuming = false,
+  shardID = 0,
+) {
+  const basicShard: BasicShard = {
+    id: shardID,
+    socket: await connectWebSocket(data.url),
+    resumeInterval: 0,
+    sessionID: "",
+    previousSequenceNumber: 0,
+    needToResume: false,
+  };
+
+  basicShards.set(basicShard.id, basicShard);
+
+  if (!resuming) {
+    // Intial identify with the gateway
+    await identify(basicShard, identifyPayload);
+  } else {
+    await resume(basicShard, identifyPayload);
+  }
+
+  for await (const message of basicShard.socket) {
+    if (typeof message === "string") {
+      const data = JSON.parse(message);
+
+      switch (data.op) {
+        case GatewayOpcode.Hello:
+          heartbeat(
+            basicShard,
+            identifyPayload,
+            (data.d as DiscordHeartbeatPayload).heartbeat_interval,
+          );
+          break;
+        case GatewayOpcode.Reconnect:
+        case GatewayOpcode.InvalidSession:
+          // When d is false we need to reidentify
+          if (!data.d) {
+            eventHandlers.debug?.(
+              { type: "invalidSession", data: { shardID: basicShard.id } },
+            );
+            createBasicShard(botGatewayData, identifyPayload, false, shardID);
+            break;
+          }
+          basicShard.needToResume = true;
+          resumeConnection(botGatewayData, identifyPayload);
+          break;
+        default:
+          if (data.t === "RESUMED") {
+            eventHandlers.debug?.(
+              { type: "resumed", data: { shardID: basicShard.id } },
+            );
+
+            basicShard.needToResume = false;
+            break;
+          }
+          // Important for RESUME
+          if (data.t === "READY") {
+            basicShard.sessionID = (data.d as ReadyPayload).session_id;
+          }
+
+          // Update the sequence number if it is present
+          if (data.s) basicShard.previousSequenceNumber = data.s;
+
+          handleDiscordPayload(data, basicShard.id);
+          break;
+      }
+    } else if (isWebSocketCloseEvent(message)) {
+      eventHandlers.debug?.(
+        { type: "websocketClose", data: { shardID: basicShard.id, message } },
+      );
+
+      // These error codes should just crash the projects
+      if ([4004, 4005, 4012, 4013, 4014].includes(message.code)) {
+        logRed(`Close :( ${JSON.stringify(message)}`);
+        eventHandlers.debug?.(
+          {
+            type: "websocketErrored",
+            data: { shardID: basicShard.id, message },
+          },
+        );
+
+        throw new Error(
+          "Shard.ts: Error occurred that is not resumeable or able to be reconnected.",
+        );
+      }
+      // These error codes can not be resumed but need to reconnect from start
+      if ([4003, 4007, 4008, 4009].includes(message.code)) {
+        eventHandlers.debug?.(
+          {
+            type: "websocketReconnecting",
+            data: { shardID: basicShard.id, message },
+          },
+        );
+        createBasicShard(botGatewayData, identifyPayload, false, shardID);
+      } else {
+        basicShard.needToResume = true;
+        resumeConnection(botGatewayData, identifyPayload);
+      }
+    }
+  }
+}
+
+async function identify(shard: BasicShard, payload: IdentifyPayload) {
+  await shard.socket.send(
+    JSON.stringify(
+      {
+        op: GatewayOpcode.Identify,
+        d: { ...payload, shard: [shard.id, payload.shard[1]] },
+      },
+    ),
+  );
+}
+
+async function resume(shard: BasicShard, payload: IdentifyPayload) {
+  await shard.socket.send(JSON.stringify({
+    op: GatewayOpcode.Resume,
+    d: {
+      ...payload,
+      session_id: shard.sessionID,
+      seq: shard.previousSequenceNumber,
+    },
+  }));
+}
+
+// TODO: If a client does not receive a heartbeat ack between its attempts at sending heartbeats, it should immediately terminate the connection with a non-1000 close code, reconnect, and attempt to resume.
+async function heartbeat(
+  shard: BasicShard,
+  payload: IdentifyPayload,
+  interval: number,
+) {
+  await delay(interval);
+  shard.socket.send(
+    JSON.stringify(
+      { op: GatewayOpcode.Heartbeat, d: shard.previousSequenceNumber },
+    ),
+  );
+  eventHandlers.debug?.(
+    {
+      type: "heartbeat",
+      data: {
+        interval,
+        previousSequenceNumber: shard.previousSequenceNumber,
+        shardID: shard.id,
+      },
+    },
+  );
+
+  heartbeat(shard, payload, interval);
+}
+
+async function resumeConnection(
+  botGatewayData: DiscordBotGatewayData,
+  payload: IdentifyPayload,
+) {
+  const shard = basicShards.get(payload.shard[0]);
+  if (!shard) {
+    eventHandlers.debug?.(
+      { type: "missingShard", data: { shardID: payload.shard[0] } },
+    );
+    return;
+  }
+
+  eventHandlers.debug?.({ type: "resuming", data: { shardID: shard.id } });
+  // Run it once
+  createBasicShard(botGatewayData, payload, true, shard.id);
+  // Then retry every 15 seconds
+  await delay(1000 * 15);
+  if (shard.needToResume) resumeConnection(botGatewayData, payload);
+}

--- a/module/client.ts
+++ b/module/client.ts
@@ -49,7 +49,7 @@ export const createClient = async (data: ClientOptions) => {
     (bits, next) => (bits |= next),
     0,
   );
-  identifyPayload.shard = [0, botGatewayData.shards]
+  identifyPayload.shard = [0, botGatewayData.shards];
 
   spawnShards(botGatewayData, identifyPayload);
 };

--- a/module/client.ts
+++ b/module/client.ts
@@ -11,7 +11,7 @@ export let eventHandlers: EventHandlers = {};
 
 export let botGatewayData: DiscordBotGatewayData;
 
-export const identifyPayload = {
+export const identifyPayload: IdentifyPayload = {
   token: "",
   compress: false,
   properties: {
@@ -22,6 +22,18 @@ export const identifyPayload = {
   intents: 0,
   shard: [0, 0],
 };
+
+export interface IdentifyPayload {
+  token: string;
+  compress: boolean;
+  properties: {
+    $os: string;
+    $browser: string;
+    $device: string;
+  };
+  intents: number;
+  shard: [number, number];
+}
 
 export const createClient = async (data: ClientOptions) => {
   if (data.eventHandlers) eventHandlers = data.eventHandlers;
@@ -37,6 +49,7 @@ export const createClient = async (data: ClientOptions) => {
     (bits, next) => (bits |= next),
     0,
   );
+  identifyPayload.shard = [0, botGatewayData.shards]
 
   spawnShards(botGatewayData, identifyPayload);
 };

--- a/types/options.ts
+++ b/types/options.ts
@@ -125,6 +125,7 @@ export interface EventHandlers {
   roleUpdate?: (guild: Guild, role: Role, cachedRole: Role) => unknown;
   roleGained?: (guild: Guild, member: Member, roleID: string) => unknown;
   roleLost?: (guild: Guild, member: Member, roleID: string) => unknown;
+  shardReady?: (shardID: number) => unknown;
   typingStart?: (data: TypingStartPayload) => unknown;
   voiceChannelJoin?: (member: Member, channelID: string) => unknown;
   voiceChannelLeave?: (member: Member, channelID: string) => unknown;

--- a/types/options.ts
+++ b/types/options.ts
@@ -67,7 +67,8 @@ export interface DebugArg {
     | "resumed"
     | "websocketClose"
     | "websocketErrored"
-    | "websocketReconnecting";
+    | "websocketReconnecting"
+    | "missingShard";
   data: unknown;
 }
 

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -7,6 +7,14 @@ export const sleep = (timeout: number) => {
   return new Promise((resolve) => setTimeout(resolve, timeout));
 };
 
+export interface BotStatusRequest {
+  status: StatusType;
+  game: {
+    name?: string;
+    type: ActivityType;
+  };
+}
+
 export function editBotsStatus(
   status: StatusType,
   name?: string,


### PR DESCRIPTION
This PR is a major feature enhancement without implementing any breaking changes but due to it's massive effect I want to give it some time for other devs to review and test.

**Understanding**
Until now Discordeno had only 1 sharding solution that was designed for large bots. This solution used the Deno Workers(which are still unstable) but it allowed insanely huge bots to work as well. However, for smaller bots, this increased a huge amount of complexity. Dealing with workers and different threads is not an easy concept so to solve this I created a second alternative sharding for now being called `basicShard`. 


**Effects**

If your bot has less than 25 shards aka less than 25,000 servers you will be automatically included in the basic shard system. This means you no longer use Deno workers which gives added benefits. 
a. Removed complexity
b. No more need to have `--unstable` flag when running the bot
c. Better errors. Deno workers hide and remove a majority of the errors so this means if there are errors, it will be a lot cleaner and helpful. As an example, some of you may have noticed these silly errors that are impossible to debug:
```ts
error: Uncaught Error: Uncaught ConnectionReset: Socket has already been closed
    at WorkerImpl.#poll ($deno$/web/workers.ts:210:17)
```
Once Deno workers are removed out of the equation it will no longer swallow the errors allowing us a much better dev experience.
d. Memory improvements

**TODO:**

This needs to be heavily tested before merging. I expect quite a few functionalities may have been lost as I may have forgotten to bring it over but after testing is done, I am certain this will work as intended with full functionality.

Update docs about this.