### PR TITLE
Add oldPresence to presenceUpdate event

### DIFF
--- a/module/shardingManager.ts
+++ b/module/shardingManager.ts
@@ -566,7 +566,7 @@ export async function handleDiscordPayload(
         const payload = data.d as PresenceUpdatePayload;
         const oldPresence = cache.presences.get(payload.user.id);
         cache.presences.set(payload.user.id, payload);
-        return eventHandlers.presenceUpdate?.(oldPresence, payload);
+        return eventHandlers.presenceUpdate?.(payload, oldPresence);
       }
 
       if (data.t === "TYPING_START") {

--- a/module/shardingManager.ts
+++ b/module/shardingManager.ts
@@ -563,7 +563,10 @@ export async function handleDiscordPayload(
       }
 
       if (data.t === "PRESENCE_UPDATE") {
-        return eventHandlers.presenceUpdate?.(data.d as PresenceUpdatePayload);
+        const payload = data.d as PresenceUpdatePayload;
+        const oldPresence = cache.presences.get(payload.user.id) ?? null;
+        cache.presences.set(payload.user.id, payload);
+        return eventHandlers.presenceUpdate?.(oldPresence, payload);
       }
 
       if (data.t === "TYPING_START") {

--- a/module/shardingManager.ts
+++ b/module/shardingManager.ts
@@ -564,7 +564,7 @@ export async function handleDiscordPayload(
 
       if (data.t === "PRESENCE_UPDATE") {
         const payload = data.d as PresenceUpdatePayload;
-        const oldPresence = cache.presences.get(payload.user.id) ?? null;
+        const oldPresence = cache.presences.get(payload.user.id);
         cache.presences.set(payload.user.id, payload);
         return eventHandlers.presenceUpdate?.(oldPresence, payload);
       }

--- a/types/options.ts
+++ b/types/options.ts
@@ -105,7 +105,10 @@ export interface EventHandlers {
     nickname: string,
     oldNickname?: string,
   ) => unknown;
-  presenceUpdate?: (data: PresenceUpdatePayload) => unknown;
+  presenceUpdate?: (
+    oldPresence: PresenceUpdatePayload | null,
+    newPresence: PresenceUpdatePayload,
+  ) => unknown;
   raw?: (data: DiscordPayload) => unknown;
   ready?: () => unknown;
   reactionAdd?: (

--- a/types/options.ts
+++ b/types/options.ts
@@ -107,7 +107,7 @@ export interface EventHandlers {
   ) => unknown;
   presenceUpdate?: (
     presence: PresenceUpdatePayload,
-    newPresence: PresenceUpdatePayload,
+    oldPresence?: PresenceUpdatePayload,
   ) => unknown;
   raw?: (data: DiscordPayload) => unknown;
   ready?: () => unknown;

--- a/types/options.ts
+++ b/types/options.ts
@@ -106,7 +106,7 @@ export interface EventHandlers {
     oldNickname?: string,
   ) => unknown;
   presenceUpdate?: (
-    oldPresence: PresenceUpdatePayload | null,
+    presence: PresenceUpdatePayload,
     newPresence: PresenceUpdatePayload,
   ) => unknown;
   raw?: (data: DiscordPayload) => unknown;

--- a/utils/cache.ts
+++ b/utils/cache.ts
@@ -3,12 +3,14 @@ import { Message } from "../structures/message.ts";
 import { Guild } from "../structures/guild.ts";
 import { Channel } from "../structures/channel.ts";
 import { delay } from "https://deno.land/std@0.61.0/async/delay.ts";
+import { PresenceUpdatePayload } from "../types/discord.ts";
 
 export interface CacheData {
   guilds: Collection<string, Guild>;
   channels: Collection<string, Channel>;
   messages: Collection<string, Message>;
   unavailableGuilds: Collection<string, number>;
+  presences: Collection<string, PresenceUpdatePayload>;
 }
 
 export const cache: CacheData = {
@@ -16,6 +18,7 @@ export const cache: CacheData = {
   channels: new Collection(),
   messages: new Collection(),
   unavailableGuilds: new Collection(),
+  presences: new Collection(),
 };
 
 async function cleanMessageCache() {


### PR DESCRIPTION
This is useful to compare the presence payload before the update and the new presence payload. Here is a simple use-case below:
```ts
import Client, { botID } from "../Discordeno/module/client.ts";
import { sendMessage } from "../Discordeno/handlers/channel.ts";
import { Intents } from "../Discordeno/types/options.ts";
import config from "./config.ts";

Client({
    token: config.token,
    intents: [Intents.GUILD_MESSAGES, Intents.GUILDS, Intents.GUILD_PRESENCES],
    eventHandlers: {
        ready: () => {
            console.log(`Logged!`);
        },
        messageCreate: (message) => {
            if (message.content === "!ping") {
                sendMessage(message.channel, "Pong");
            }
        },
        presenceUpdate: (oldPresence, newPresence) => {
            if (!oldPresence) return;
            if (oldPresence.status !== 'offline' && newPresence.status === 'offline') {
                console.log(`User ${newPresence.user.id} is now offline!`);
            } else if(oldPresence.status === 'offline' && newPresence.status !== 'offline') {
                console.log(`User ${newPresence.user.id} is now online!`);
            }
        }
    }
});
```

It seems me logical to have the `oldPresence` parameter before the `newPresence` one ([as Discord.js does](https://github.com/discordjs/discord.js/blob/2338594030ff8839e36406ee979cc5f65253d6ca/src/client/actions/PresenceUpdate.js#L39)), but it would mean that this PR includes a breaking change, so maybe it would be better to keep the new payload before, and add the `oldPresence` after. 