### PR TITLE
[v7] Fix broken createGuildChannel

### DIFF
--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -4,7 +4,7 @@ import { RoleData } from "./role.ts";
 import { MemberCreatePayload } from "./member.ts";
 import { Activity } from "./message.ts";
 import { ClientStatusPayload } from "./presence.ts";
-import { ChannelCreatePayload } from "./channel.ts";
+import { ChannelCreatePayload, ChannelTypes } from "./channel.ts";
 
 export interface GuildRolePayload {
   /** The id of the guild */
@@ -446,14 +446,6 @@ export enum AuditLogs {
   INTEGRATION_DELETE,
 }
 
-export type ChannelTypeText =
-  | "text"
-  | "dm"
-  | "news"
-  | "voice"
-  | "category"
-  | "store";
-
 export interface Overwrite {
   /** The role or user id */
   id: string;
@@ -482,7 +474,7 @@ export interface RawOverwrite {
 
 export interface ChannelCreateOptions {
   /** The type of the channel */
-  type?: ChannelTypeText;
+  type?: ChannelTypes;
   /** The channel topic. (0-1024 characters) */
   topic?: string;
   /** The bitrate(in bits) of the voice channel. */


### PR DESCRIPTION
Due to changes in v7 of which type you allow for channel type, creating channels does not work anymore.

This PR removes the channel types in types/guild.ts, and uses the channel types from types/channel.ts instead.