### PR TITLE
Use ClientOptions#properties option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "deno.enable": true,
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "denoland.vscode-deno"
 }

--- a/src/module/client.ts
+++ b/src/module/client.ts
@@ -1,5 +1,5 @@
 import { endpoints } from "../constants/discord.ts";
-import { DiscordBotGatewayData } from "../types/discord.ts";
+import { DiscordBotGatewayData, Properties } from "../types/discord.ts";
 import { ClientOptions, EventHandlers } from "../types/options.ts";
 import { RequestManager } from "./requestManager.ts";
 import { spawnShards } from "./shardingManager.ts";
@@ -26,11 +26,7 @@ export const identifyPayload: IdentifyPayload = {
 export interface IdentifyPayload {
   token: string;
   compress: boolean;
-  properties: {
-    $os: string;
-    $browser: string;
-    $device: string;
-  };
+  properties: Properties;
   intents: number;
   shard: [number, number];
 }

--- a/src/module/client.ts
+++ b/src/module/client.ts
@@ -36,6 +36,7 @@ export interface IdentifyPayload {
 }
 
 export const createClient = async (data: ClientOptions) => {
+  if (data.properties) identifyPayload.properties = data.properties;
   if (data.eventHandlers) eventHandlers = data.eventHandlers;
   authorization = `Bot ${data.token}`;
 


### PR DESCRIPTION
The option ClientOptions#properties was completely disregarded previously. However, it is now taken into account:
```ts
createClient({
    ...,
    properties: {
        $os: "...",
        $browser: "...",
        $device: "..."
    }
});
```

*Did not format the entire source folder since that would be irrelevant to this PR.