### PR TITLE
Rename leave() to leaveGuild() to remove ambiguity

### DIFF
--- a/src/handlers/guild.ts
+++ b/src/handlers/guild.ts
@@ -570,7 +570,7 @@ export function getInvites(guildID: string) {
 }
 
 /** Leave a guild */
-export function leave(guildID: string) {
+export function leaveGuild(guildID: string) {
   return RequestManager.delete(endpoints.GUILD_LEAVE(guildID));
 }
 


### PR DESCRIPTION
Renamed leave() to leaveGuild() to remove ambiguity.