### PR TITLE
docs(Correct docsUrl)

### DIFF
--- a/docs/config.js
+++ b/docs/config.js
@@ -66,7 +66,7 @@ const config = {
     title: "Discordeno",
     description: "Easy Deno module for Discord API interactions..",
     ogImage: "https://i.imgur.com/7O5E6hI.png",
-    docsLocation: "https://github.com/Daggy1234/Discordeno/tree/master/docs/content",
+    docsLocation: "https://github.com/Skillz4Killz/Discordeno/tree/master/docs/content",
     favicon: "",
   },
   pwa: {

--- a/docs/config.js
+++ b/docs/config.js
@@ -66,7 +66,7 @@ const config = {
     title: "Discordeno",
     description: "Easy Deno module for Discord API interactions..",
     ogImage: "https://i.imgur.com/7O5E6hI.png",
-    docsLocation: "https://github.com/Skillz4Killz/Discordeno",
+    docsLocation: "https://github.com/Daggy1234/Discordeno/tree/master/docs/content",
     favicon: "",
   },
   pwa: {


### PR DESCRIPTION
## Description

In the Documentation, the DocsUrl is not correctly set. This makes the `Edit on github ` not show the Correct Location. This Pr will fix this.
## Issues

<!-- Link any relevant issues here if you like? -->
