### PR TITLE
fix: resume connect of shard socket if lost between heartbeats

### DIFF
--- a/src/module/basicShard.ts
+++ b/src/module/basicShard.ts
@@ -206,7 +206,7 @@ function resume(shard: BasicShard, payload: IdentifyPayload) {
 async function heartbeat(
   shard: BasicShard,
   interval: number,
-  payload: IdentifyPayload
+  payload: IdentifyPayload,
 ) {
   // We lost socket connection between heartbeats, resume connection
   if (shard.socket.isClosed) {

--- a/src/module/basicShard.ts
+++ b/src/module/basicShard.ts
@@ -122,6 +122,7 @@ export async function createBasicShard(
             heartbeat(
               basicShard,
               (data.d as DiscordHeartbeatPayload).heartbeat_interval,
+              identifyPayload,
             );
           }
           break;
@@ -205,8 +206,12 @@ function resume(shard: BasicShard, payload: IdentifyPayload) {
 async function heartbeat(
   shard: BasicShard,
   interval: number,
+  payload: IdentifyPayload
 ) {
+  // We lost socket connection between heartbeats, resume connection
   if (shard.socket.isClosed) {
+    shard.needToResume = true;
+    resumeConnection(botGatewayData, payload, shard.id);
     heartbeating.delete(shard.id);
     return;
   }
@@ -248,7 +253,7 @@ async function heartbeat(
     },
   );
   await delay(interval);
-  heartbeat(shard, interval);
+  heartbeat(shard, interval, payload);
 }
 
 async function resumeConnection(


### PR DESCRIPTION
Fixes 

Resume connect of shard socket if lost between heartbeats.

The socket can be closed in between heartbeats, and the connection needs to be recreated. [Here](https://github.com/Skillz4Killz/Discordeno/blob/master/src/module/basicShard.ts#L209-L212) we just return and the bot stops working.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes

_Testing more thoroughly with my bot at the moment_
