### PR TITLE
fix: guildMemberRemove event triggered twice

### DIFF
--- a/src/controllers/members.ts
+++ b/src/controllers/members.ts
@@ -41,11 +41,6 @@ export async function handleInternalGuildMemberRemove(data: DiscordPayload) {
     member || payload.user,
   );
 
-  eventHandlers.guildMemberRemove?.(
-    guild,
-    member || payload.user,
-  );
-
   guild.members.delete(payload.user.id);
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The event *guildMemberRemove* is triggered twice.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
