### PR TITLE
Resolve promise for all botHasChannelPermissions()

### DIFF
--- a/src/handlers/channel.ts
+++ b/src/handlers/channel.ts
@@ -43,16 +43,22 @@ export async function getMessage(
   channelID: string,
   id: string,
 ) {
+  const hasViewChannelPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.VIEW_CHANNEL],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.VIEW_CHANNEL])
+    !hasViewChannelPerm
   ) {
     throw new Error(Errors.MISSING_VIEW_CHANNEL);
   }
+
+  const hasReadMessageHistoryPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.READ_MESSAGE_HISTORY],
+  );
   if (
-    !botHasChannelPermissions(
-      channelID,
-      [Permissions.READ_MESSAGE_HISTORY],
-    )
+    !hasReadMessageHistoryPerm
   ) {
     throw new Error(Errors.MISSING_READ_MESSAGE_HISTORY);
   }
@@ -72,16 +78,22 @@ export async function getMessages(
     | GetMessagesAround
     | GetMessages,
 ) {
+  const hasViewChannelPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.VIEW_CHANNEL],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.VIEW_CHANNEL])
+    !hasViewChannelPerm
   ) {
     throw new Error(Errors.MISSING_VIEW_CHANNEL);
   }
+
+  const hasReadMessageHistoryPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.READ_MESSAGE_HISTORY],
+  );
   if (
-    !botHasChannelPermissions(
-      channelID,
-      [Permissions.READ_MESSAGE_HISTORY],
-    )
+    !hasReadMessageHistoryPerm
   ) {
     throw new Error(Errors.MISSING_READ_MESSAGE_HISTORY);
   }
@@ -109,24 +121,34 @@ export async function sendMessage(
   content: string | MessageContent,
 ) {
   if (typeof content === "string") content = { content };
+  const hasSendMessagesPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.SEND_MESSAGES],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.SEND_MESSAGES])
+    !hasSendMessagesPerm
   ) {
     throw new Error(Errors.MISSING_SEND_MESSAGES);
   }
+
+  const hasSendTtsMessagesPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.SEND_TTS_MESSAGES],
+  );
   if (
     content.tts &&
-    !botHasChannelPermissions(
-      channelID,
-      [Permissions.SEND_TTS_MESSAGES],
-    )
+    !hasSendTtsMessagesPerm
   ) {
     throw new Error(Errors.MISSING_SEND_TTS_MESSAGE);
   }
 
+  const hasEmbedLinksPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.EMBED_LINKS],
+  );
   if (
     content.embed &&
-    !botHasChannelPermissions(channelID, [Permissions.EMBED_LINKS])
+    !hasEmbedLinksPerm
   ) {
     throw new Error(Errors.MISSING_EMBED_LINKS);
   }
@@ -183,13 +205,17 @@ export async function sendMessage(
 }
 
 /** Delete messages from the channel. 2-100. Requires the MANAGE_MESSAGES permission */
-export function deleteMessages(
+export async function deleteMessages(
   channelID: string,
   ids: string[],
   reason?: string,
 ) {
+  const hasManageMessages = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_MESSAGES],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.MANAGE_MESSAGES])
+    !hasManageMessages
   ) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
   }
@@ -210,9 +236,13 @@ export function deleteMessages(
 }
 
 /** Gets the invites for this channel. Requires MANAGE_CHANNEL */
-export function getChannelInvites(channelID: string) {
+export async function getChannelInvites(channelID: string) {
+  const hasManagaChannels = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_CHANNELS],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.MANAGE_CHANNELS])
+    !hasManagaChannels
   ) {
     throw new Error(Errors.MISSING_MANAGE_CHANNELS);
   }
@@ -220,12 +250,16 @@ export function getChannelInvites(channelID: string) {
 }
 
 /** Creates a new invite for this channel. Requires CREATE_INSTANT_INVITE */
-export function createInvite(channelID: string, options: CreateInviteOptions) {
+export async function createInvite(
+  channelID: string,
+  options: CreateInviteOptions,
+) {
+  const hasCreateInstantInvitePerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.CREATE_INSTANT_INVITE],
+  );
   if (
-    !botHasChannelPermissions(
-      channelID,
-      [Permissions.CREATE_INSTANT_INVITE],
-    )
+    !hasCreateInstantInvitePerm
   ) {
     throw new Error(Errors.MISSING_CREATE_INSTANT_INVITE);
   }
@@ -233,9 +267,13 @@ export function createInvite(channelID: string, options: CreateInviteOptions) {
 }
 
 /** Gets the webhooks for this channel. Requires MANAGE_WEBHOOKS */
-export function getChannelWebhooks(channelID: string) {
+export async function getChannelWebhooks(channelID: string) {
+  const hasManageWebhooksPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_WEBHOOKS],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.MANAGE_WEBHOOKS])
+    !hasManageWebhooksPerm
   ) {
     throw new Error(Errors.MISSING_MANAGE_WEBHOOKS);
   }
@@ -288,12 +326,16 @@ function processEditChannelQueue() {
   }
 }
 
-export function editChannel(
+export async function editChannel(
   channelID: string,
   options: ChannelEditOptions,
 ) {
+  const hasManageChannelsPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_CHANNELS],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.MANAGE_CHANNELS])
+    !hasManageChannelsPerm
   ) {
     throw new Error(Errors.MISSING_MANAGE_CHANNELS);
   }
@@ -356,8 +398,12 @@ export async function followChannel(
   sourceChannelID: string,
   targetChannelID: string,
 ) {
+  const hasManageWebhooksPerm = await botHasChannelPermissions(
+    targetChannelID,
+    [Permissions.MANAGE_WEBHOOKS],
+  );
   if (
-    !botHasChannelPermissions(targetChannelID, [Permissions.MANAGE_WEBHOOKS])
+    !hasManageWebhooksPerm
   ) {
     throw new Error(Errors.MISSING_MANAGE_CHANNELS);
   }

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -38,11 +38,12 @@ export async function deleteMessage(
 ) {
   if (message.author.id !== botID) {
     // This needs to check the channels permission not the guild permission
+    const hasManageMessages = await botHasChannelPermissions(
+      message.channelID,
+      [Permissions.MANAGE_MESSAGES],
+    );
     if (
-      !botHasChannelPermissions(
-        message.channelID,
-        [Permissions.MANAGE_MESSAGES],
-      )
+      !hasManageMessages
     ) {
       throw new Error(Errors.MISSING_MANAGE_MESSAGES);
     }
@@ -57,9 +58,13 @@ export async function deleteMessage(
 }
 
 /** Pin a message in a channel. Requires MANAGE_MESSAGES. Max pins allowed in a channel = 50. */
-export function pin(channelID: string, messageID: string) {
+export async function pin(channelID: string, messageID: string) {
+  const hasManageMessagesPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_MESSAGES],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.MANAGE_MESSAGES])
+    !hasManageMessagesPerm
   ) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
   }
@@ -67,9 +72,13 @@ export function pin(channelID: string, messageID: string) {
 }
 
 /** Unpin a message in a channel. Requires MANAGE_MESSAGES. */
-export function unpin(channelID: string, messageID: string) {
+export async function unpin(channelID: string, messageID: string) {
+  const hasManageMessagesPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_MESSAGES],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.MANAGE_MESSAGES])
+    !hasManageMessagesPerm
   ) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
   }
@@ -79,17 +88,25 @@ export function unpin(channelID: string, messageID: string) {
 }
 
 /** Create a reaction for the message. Reaction takes the form of **name:id** for custom guild emoji, or Unicode characters. Requires READ_MESSAGE_HISTORY and ADD_REACTIONS */
-export function addReaction(
+export async function addReaction(
   channelID: string,
   messageID: string,
   reaction: string,
 ) {
-  if (!botHasChannelPermissions(channelID, [Permissions.ADD_REACTIONS])) {
+  const hasAddReactionsPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.ADD_REACTIONS],
+  );
+  if (!hasAddReactionsPerm) {
     throw new Error(Errors.MISSING_ADD_REACTIONS);
   }
 
+  const hasReadMessageHistoryPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.READ_MESSAGE_HISTORY],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.READ_MESSAGE_HISTORY])
+    !hasReadMessageHistoryPerm
   ) {
     throw new Error(Errors.MISSING_READ_MESSAGE_HISTORY);
   }
@@ -143,13 +160,17 @@ export function removeReaction(
 }
 
 /** Removes a reaction from the specified user on this message. Reaction takes the form of **name:id** for custom guild emoji, or Unicode characters. */
-export function removeUserReaction(
+export async function removeUserReaction(
   channelID: string,
   messageID: string,
   reaction: string,
   userID: string,
 ) {
-  if (!botHasChannelPermissions(channelID, [Permissions.MANAGE_MESSAGES])) {
+  const hasManageMessagesPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_MESSAGES],
+  );
+  if (!hasManageMessagesPerm) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
   }
 
@@ -164,9 +185,13 @@ export function removeUserReaction(
 }
 
 /** Removes all reactions for all emojis on this message. */
-export function removeAllReactions(channelID: string, messageID: string) {
+export async function removeAllReactions(channelID: string, messageID: string) {
+  const hasManageMessagesPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_MESSAGES],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.MANAGE_MESSAGES])
+    !hasManageMessagesPerm
   ) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
   }
@@ -176,13 +201,17 @@ export function removeAllReactions(channelID: string, messageID: string) {
 }
 
 /** Removes all reactions for a single emoji on this message. Reaction takes the form of **name:id** for custom guild emoji, or Unicode characters. */
-export function removeReactionEmoji(
+export async function removeReactionEmoji(
   channelID: string,
   messageID: string,
   reaction: string,
 ) {
+  const hasManageMessagesPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_MESSAGES],
+  );
   if (
-    !botHasChannelPermissions(channelID, [Permissions.MANAGE_MESSAGES])
+    !hasManageMessagesPerm
   ) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
   }
@@ -216,18 +245,23 @@ export async function editMessage(
 
   if (typeof content === "string") content = { content };
 
+  const hasSendMessagesPerm = await botHasChannelPermissions(
+    message.channelID,
+    [Permissions.SEND_MESSAGES],
+  );
   if (
-    !botHasChannelPermissions(message.channelID, [Permissions.SEND_MESSAGES])
+    !hasSendMessagesPerm
   ) {
     throw new Error(Errors.MISSING_SEND_MESSAGES);
   }
 
+  const hasSendTtsMessagesPerm = await botHasChannelPermissions(
+    message.channelID,
+    [Permissions.SEND_TTS_MESSAGES],
+  );
   if (
     content.tts &&
-    !botHasChannelPermissions(
-      message.channelID,
-      [Permissions.SEND_TTS_MESSAGES],
-    )
+    !hasSendTtsMessagesPerm
   ) {
     throw new Error(Errors.MISSING_SEND_TTS_MESSAGE);
   }

--- a/src/handlers/webhook.ts
+++ b/src/handlers/webhook.ts
@@ -20,11 +20,12 @@ export async function createWebhook(
   channelID: string,
   options: WebhookCreateOptions,
 ) {
+  const hasManageWebhooksPerm = await botHasChannelPermissions(
+    channelID,
+    [Permissions.MANAGE_WEBHOOKS],
+  );
   if (
-    !botHasChannelPermissions(
-      channelID,
-      [Permissions.MANAGE_WEBHOOKS],
-    )
+    !hasManageWebhooksPerm
   ) {
     throw new Error(Errors.MISSING_MANAGE_WEBHOOKS);
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add `await` to all non-resolved botHasChannelPermissions calls.

Closes #174 
Closes #173 

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
