### PR TITLE
Convert Retry-After to ms

### DIFF
--- a/src/module/requestManager.ts
+++ b/src/module/requestManager.ts
@@ -365,7 +365,7 @@ function processHeaders(url: string, headers: Headers) {
 
   // If there is no remaining global limit, we save it in cache
   if (global) {
-    const reset = Date.now() + Number(retryAfter);
+    const reset = Date.now() + (Number(retryAfter) * 1000);
     eventHandlers.debug?.(
       { type: "globallyRateLimited", data: { url, reset } },
     );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The Retry-After header's value is in seconds (sent by the API); however, Discordeno treats the value as milliseconds instead of seconds. This PR converts the seconds received by API to ms.

> The Retry-After header is now based in seconds instead of milliseconds (e.g. 123 means 123 seconds)
v8 CHANGELOG: https://discord.com/developers/docs/change-log

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
