### PR TITLE
[BREAKING] move guild.members to cache.members

### DIFF
--- a/src/controllers/bans.ts
+++ b/src/controllers/bans.ts
@@ -10,7 +10,7 @@ export async function handleInternalGuildBanAdd(data: DiscordPayload) {
   const guild = await cacheHandlers.get("guilds", payload.guild_id);
   if (!guild) return;
 
-  const member = guild.members.get(payload.user.id);
+  const member = await cacheHandlers.get("members", payload.user.id);
   eventHandlers.guildBanAdd?.(guild, member || payload.user);
 }
 
@@ -21,6 +21,6 @@ export async function handleInternalGuildBanRemove(data: DiscordPayload) {
   const guild = await cacheHandlers.get("guilds", payload.guild_id);
   if (!guild) return;
 
-  const member = guild.members.get(payload.user.id);
+  const member = await cacheHandlers.get("members", payload.user.id);
   eventHandlers.guildBanRemove?.(guild, member || payload.user);
 }

--- a/src/controllers/cache.ts
+++ b/src/controllers/cache.ts
@@ -1,5 +1,6 @@
 import { Channel } from "../structures/channel.ts";
 import { Guild } from "../structures/guild.ts";
+import { Member } from "../structures/member.ts";
 import { Message } from "../structures/message.ts";
 import { PresenceUpdatePayload } from "../types/discord.ts";
 import { cache } from "../utils/cache.ts";
@@ -7,10 +8,11 @@ import { Collection } from "../utils/collection.ts";
 
 export type TableName =
   | "guilds"
+  | "unavailableGuilds"
   | "channels"
   | "messages"
-  | "presences"
-  | "unavailableGuilds";
+  | "members"
+  | "presences";
 
 function set(
   table: "guilds",
@@ -28,6 +30,11 @@ function set(
   value: Message,
 ): Promise<Collection<string, Message>>;
 function set(
+  table: "members",
+  key: string,
+  value: Member,
+): Promise<Collection<string, Member>>;
+function set(
   table: "presences",
   key: string,
   value: PresenceUpdatePayload,
@@ -44,6 +51,7 @@ async function set(table: TableName, key: string, value: any) {
 function get(table: "guilds", key: string): Promise<Guild | undefined>;
 function get(table: "channels", key: string): Promise<Channel | undefined>;
 function get(table: "messages", key: string): Promise<Message | undefined>;
+function get(table: "members", key: string): Promise<Member | undefined>;
 function get(
   table: "presences",
   key: string,
@@ -73,6 +81,10 @@ function forEach(
   callback: (value: Message, key: string, map: Map<string, Message>) => unknown,
 ): void;
 function forEach(
+  table: "members",
+  callback: (value: Member, key: string, map: Map<string, Member>) => unknown,
+): void;
+function forEach(
   table: TableName,
   callback: (value: any, key: string, map: Map<string, any>) => unknown,
 ) {
@@ -82,20 +94,24 @@ function forEach(
 function filter(
   table: "guilds",
   callback: (value: Guild, key: string) => boolean,
-): Collection<string, Guild>;
+): Promise<Collection<string, Guild>>;
 function filter(
   table: "unavailableGuilds",
   callback: (value: Guild, key: string) => boolean,
-): Collection<string, Guild>;
+): Promise<Collection<string, Guild>>;
 function filter(
   table: "channels",
   callback: (value: Channel, key: string) => boolean,
-): Collection<string, Channel>;
+): Promise<Collection<string, Channel>>;
 function filter(
   table: "messages",
   callback: (value: Message, key: string) => boolean,
-): Collection<string, Message>;
+): Promise<Collection<string, Message>>;
 function filter(
+  table: "members",
+  callback: (value: Member, key: string) => boolean,
+): Promise<Collection<string, Member>>;
+async function filter(
   table: TableName,
   callback: (value: any, key: string) => boolean,
 ) {

--- a/src/controllers/messages.ts
+++ b/src/controllers/messages.ts
@@ -19,26 +19,20 @@ export async function handleInternalMessageCreate(data: DiscordPayload) {
     ? await cacheHandlers.get("guilds", payload.guild_id)
     : undefined;
 
-  if (payload.member) {
+  if (payload.member && guild) {
     // If in a guild cache the author as a member
-    guild?.members.set(
-      payload.author.id,
-      await structures.createMember(
+    await structures.createMember(
         { ...payload.member, user: payload.author },
         guild.id,
-      ),
     );
   }
 
-  payload.mentions.forEach(async (mention) => {
+  payload.mentions.forEach((mention) => {
     // Cache the member if its a valid member
-    if (mention.member) {
-      guild?.members.set(
-        mention.id,
-        await structures.createMember(
+    if (mention.member && guild) {
+        structures.createMember(
           { ...mention.member, user: mention },
           guild.id,
-        ),
       );
     }
   });

--- a/src/controllers/reactions.ts
+++ b/src/controllers/reactions.ts
@@ -39,13 +39,9 @@ export async function handleInternalMessageReactionAdd(data: DiscordPayload) {
 
   if (payload.member && payload.guild_id) {
     const guild = await cacheHandlers.get("guilds", payload.guild_id);
-    guild?.members.set(
-      payload.member.user.id,
-      await structures.createMember(
-        payload.member,
-        guild.id,
-      ),
-    );
+    if (guild) {
+      await structures.createMember(payload.member, guild.id);
+    }
   }
 
   const uncachedOptions = {
@@ -95,13 +91,12 @@ export async function handleInternalMessageReactionRemove(
 
   if (payload.member && payload.guild_id) {
     const guild = await cacheHandlers.get("guilds", payload.guild_id);
-    guild?.members.set(
-      payload.member.user.id,
+    if (guild) {
       await structures.createMember(
-        payload.member,
-        guild.id,
-      ),
-    );
+          payload.member,
+          guild.id,
+      );
+    }
   }
 
   const uncachedOptions = {

--- a/src/controllers/roles.ts
+++ b/src/controllers/roles.ts
@@ -29,8 +29,16 @@ export async function handleInternalGuildRoleDelete(data: DiscordPayload) {
   eventHandlers.roleDelete?.(guild, cachedRole);
 
   // For bots without GUILD_MEMBERS member.roles is never updated breaking permissions checking.
-  guild.members.forEach((member) => {
-    member.roles = member.roles.filter((id) => id !== payload.role_id);
+  cacheHandlers.forEach("members", member => {
+    // Not in the relevant guild so just skip.
+    if (!member.guilds.has(guild.id)) return;
+
+    member.guilds.forEach(g => {
+      // Member does not have this role
+      if (!g.roles.includes(payload.role_id)) return;
+      // Remove this role from the members cache
+      g.roles = g.roles.filter(id => id !== payload.role_id);
+    })
   });
 }
 

--- a/src/handlers/guild.ts
+++ b/src/handlers/guild.ts
@@ -216,7 +216,6 @@ export async function getMember(
   ) as MemberCreatePayload;
 
   const member = await structures.createMember(data, guildID);
-  guild?.members.set(id, member);
   return member;
 }
 

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -225,11 +225,11 @@ export async function getReactions(message: Message, reaction: string) {
   const result = (await RequestManager.get(
     endpoints.CHANNEL_MESSAGE_REACTION(message.channelID, message.id, reaction),
   )) as UserPayload[];
-  const guild = await cacheHandlers.get("guilds", message.guildID);
 
-  return result.map((res) => {
-    return guild?.members.get(res.id) || res;
-  });
+  return Promise.all(result.map(async (res) => {
+    const member = await cacheHandlers.get("members", res.id);
+    return member || res;
+  }));
 }
 
 /** Edit the message. */

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -1,5 +1,7 @@
-import { MemberCreatePayload } from "../types/member.ts";
+import { cacheHandlers } from "../controllers/cache.ts";
+import { GuildMember, MemberCreatePayload } from "../types/member.ts";
 import { Unpromise } from "../types/misc.ts";
+import { Collection } from "../utils/collection.ts";
 
 export async function createMember(data: MemberCreatePayload, guildID: string) {
   const {
@@ -14,21 +16,64 @@ export async function createMember(data: MemberCreatePayload, guildID: string) {
     ...user
   } = data.user || {};
 
+  const cached = await cacheHandlers.get("members", user.id);
+  if (cached) {
+    // Check if any of the others need updating
+    if (mfaEnabled) cached.mfaEnabled = mfaEnabled;
+    if (premiumType) cached.premiumType = premiumType;
+    if (user.username) cached.username = user.username;
+    if (user.discriminator) cached.discriminator = user.discriminator;
+    if (user.avatar) cached.avatar = user.avatar;
+    if (user.bot) cached.bot = user.bot;
+    if (user.system) cached.system = user.system;
+    if (user.locale) cached.locale = user.locale;
+    if (user.verified) cached.verified = user.verified;
+    if (user.email) cached.email = user.email;
+    if (user.flags) cached.flags = user.flags;
+
+    // Set the guild data
+    cached.guilds.set(guildID, {
+      /** The user's guild nickname if one is set. */
+      nick: data.nick,
+      /** Array of role ids that the member has */
+      roles: data.roles,
+      /** When the user joined the guild. */
+      joinedAt: Date.parse(joinedAt),
+      /** When the user used their nitro boost on the server. */
+      premiumSince: premiumSince ? Date.parse(premiumSince) : undefined,
+      /** Whether the user is deafened in voice channels */
+      deaf: data.deaf,
+      /** Whether the user is muted in voice channels */
+      mute: data.mute,
+    });
+  }
+
   const member = {
     ...rest,
     // Only use those that we have not removed above
-    user: user,
+    ...user,
     /** When the user joined the guild */
     joinedAt: Date.parse(joinedAt),
     /** When the user used their nitro boost on the server. */
     premiumSince: premiumSince ? Date.parse(premiumSince) : undefined,
-    /** The guild id where this member exists */
-    guildID,
     /** Whether or not this user has 2FA enabled. */
     mfaEnabled,
     /** The premium type for this user */
     premiumType,
+    /** The guild related data mapped by guild id */
+    guilds: new Collection<string, GuildMember>(),
   };
+
+  member.guilds.set(guildID, {
+    nick: data.nick,
+    roles: data.roles,
+    joinedAt: Date.parse(joinedAt),
+    premiumSince: premiumSince ? Date.parse(premiumSince) : undefined,
+    deaf: data.deaf,
+    mute: data.mute,
+  });
+
+  await cacheHandlers.set("members", member.id, member);
 
   return member;
 }

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -29,3 +29,18 @@ export interface MemberCreatePayload {
   /** Whether the user is muted in voice channels */
   mute: boolean;
 }
+
+export interface GuildMember {
+  /** The user's guild nickname if one is set. */
+  nick?: string;
+  /** Array of role ids that the member has */
+  roles: string[];
+  /** When the user joined the guild. */
+  joinedAt: number;
+  /** When the user used their nitro boost on the server. */
+  premiumSince?: number;
+  /** Whether the user is deafened in voice channels */
+  deaf: boolean;
+  /** Whether the user is muted in voice channels */
+  mute: boolean;
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,5 +1,6 @@
 import { Channel } from "../structures/channel.ts";
 import { Guild } from "../structures/guild.ts";
+import { Member } from "../structures/member.ts";
 import { Message } from "../structures/message.ts";
 import { PresenceUpdatePayload } from "../types/discord.ts";
 import { Collection } from "./collection.ts";
@@ -9,6 +10,7 @@ export interface CacheData {
   guilds: Collection<string, Guild>;
   channels: Collection<string, Channel>;
   messages: Collection<string, Message>;
+  members: Collection<string, Member>;
   unavailableGuilds: Collection<string, number>;
   presences: Collection<string, PresenceUpdatePayload>;
   fetchAllMembersProcessingRequests: Collection<string, Function>;
@@ -19,6 +21,7 @@ export const cache: CacheData = {
   guilds: new Collection(),
   channels: new Collection(),
   messages: new Collection(),
+  members: new Collection(),
   unavailableGuilds: new Collection(),
   presences: new Collection(),
   fetchAllMembersProcessingRequests: new Collection(),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR moves the guild.members to a cache.members to optimize ram usage. With 100 guilds per user, usernames, discriminators, etc were all duplicated and eating up ram. Moving to cache makes that all saved ram.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
