### PR TITLE
[BREAKING] Permission consistency

### DIFF
--- a/src/handlers/channel.ts
+++ b/src/handlers/channel.ts
@@ -13,29 +13,26 @@ import {
   MessageContent,
 } from "../types/channel.ts";
 import { Errors } from "../types/errors.ts";
-import { PermissionOverwrite } from "../types/guild.ts";
+import { RawOverwrite } from "../types/guild.ts";
 import { MessageCreateOptions } from "../types/message.ts";
-import { Permissions } from "../types/permission.ts";
+import { Permissions, Permission } from "../types/permission.ts";
 import { endpoints } from "../utils/constants.ts";
-import {
-  botHasChannelPermissions,
-  calculateBits,
-} from "../utils/permissions.ts";
+import { botHasChannelPermissions, } from "../utils/permissions.ts";
 
 /** Checks if a channel overwrite for a user id or a role id has permission in this channel */
 export function channelOverwriteHasPermission(
   guildID: string,
   id: string,
-  overwrites: PermissionOverwrite[],
-  permissions: Permissions[],
+  overwrites: RawOverwrite[],
+  permissions: Permission[],
 ) {
   const overwrite = overwrites.find((perm) => perm.id === id) ||
     overwrites.find((perm) => perm.id === guildID);
 
   return permissions.every((perm) => {
     if (overwrite) {
-      const allowBits = calculateBits(overwrite.allow);
-      const denyBits = calculateBits(overwrite.deny);
+      const allowBits = overwrite.allow;
+      const denyBits = overwrite.deny;
       if (BigInt(denyBits) & BigInt(perm)) return false;
       if (BigInt(allowBits) & BigInt(perm)) return true;
     }
@@ -50,7 +47,7 @@ export async function getMessage(
 ) {
   const hasViewChannelPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.VIEW_CHANNEL],
+    ["VIEW_CHANNEL"],
   );
   if (
     !hasViewChannelPerm
@@ -60,7 +57,7 @@ export async function getMessage(
 
   const hasReadMessageHistoryPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.READ_MESSAGE_HISTORY],
+    ["READ_MESSAGE_HISTORY"],
   );
   if (
     !hasReadMessageHistoryPerm
@@ -85,7 +82,7 @@ export async function getMessages(
 ) {
   const hasViewChannelPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.VIEW_CHANNEL],
+    ["VIEW_CHANNEL"],
   );
   if (
     !hasViewChannelPerm
@@ -95,7 +92,7 @@ export async function getMessages(
 
   const hasReadMessageHistoryPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.READ_MESSAGE_HISTORY],
+    ["READ_MESSAGE_HISTORY"],
   );
   if (
     !hasReadMessageHistoryPerm
@@ -128,7 +125,7 @@ export async function sendMessage(
   if (typeof content === "string") content = { content };
   const hasSendMessagesPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.SEND_MESSAGES],
+    ["SEND_MESSAGES"],
   );
   if (
     !hasSendMessagesPerm
@@ -138,7 +135,7 @@ export async function sendMessage(
 
   const hasSendTtsMessagesPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.SEND_TTS_MESSAGES],
+    ["SEND_TTS_MESSAGES"],
   );
   if (
     content.tts &&
@@ -149,7 +146,7 @@ export async function sendMessage(
 
   const hasEmbedLinksPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.EMBED_LINKS],
+    ["EMBED_LINKS"],
   );
   if (
     content.embed &&
@@ -192,7 +189,7 @@ export async function sendMessage(
       if (
         !(await botHasChannelPermissions(
           channelID,
-          [Permissions.READ_MESSAGE_HISTORY],
+          ["READ_MESSAGE_HISTORY"],
         ))
       ) {
         throw new Error(Errors.MISSING_SEND_MESSAGES);
@@ -236,7 +233,7 @@ export async function deleteMessages(
 ) {
   const hasManageMessages = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_MESSAGES],
+    ["MANAGE_MESSAGES"],
   );
   if (
     !hasManageMessages
@@ -263,7 +260,7 @@ export async function deleteMessages(
 export async function getChannelInvites(channelID: string) {
   const hasManagaChannels = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_CHANNELS],
+    ["MANAGE_CHANNELS"],
   );
   if (
     !hasManagaChannels
@@ -280,7 +277,7 @@ export async function createInvite(
 ) {
   const hasCreateInstantInvitePerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.CREATE_INSTANT_INVITE],
+    ["CREATE_INSTANT_INVITE"],
   );
   if (
     !hasCreateInstantInvitePerm
@@ -294,7 +291,7 @@ export async function createInvite(
 export async function getChannelWebhooks(channelID: string) {
   const hasManageWebhooksPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_WEBHOOKS],
+    ["MANAGE_WEBHOOKS"],
   );
   if (
     !hasManageWebhooksPerm
@@ -357,7 +354,7 @@ export async function editChannel(
 ) {
   const hasManageChannelsPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_CHANNELS],
+    ["MANAGE_CHANNELS"],
   );
   if (
     !hasManageChannelsPerm
@@ -428,7 +425,7 @@ export async function followChannel(
 ) {
   const hasManageWebhooksPerm = await botHasChannelPermissions(
     targetChannelID,
-    [Permissions.MANAGE_WEBHOOKS],
+    ["MANAGE_WEBHOOKS"],
   );
   if (
     !hasManageWebhooksPerm

--- a/src/handlers/guild.ts
+++ b/src/handlers/guild.ts
@@ -109,7 +109,7 @@ export async function createGuildChannel(
 ) {
   const hasPerm = await botHasPermission(
     guild.id,
-    [Permissions.MANAGE_CHANNELS],
+    ["MANAGE_CHANNELS"],
   );
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_CHANNELS);
@@ -146,7 +146,7 @@ export async function deleteChannel(
 ) {
   const hasPerm = await botHasPermission(
     guildID,
-    [Permissions.MANAGE_CHANNELS],
+    ["MANAGE_CHANNELS"],
   );
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_CHANNELS);
@@ -243,7 +243,7 @@ export async function createEmoji(
   image: string,
   options: CreateEmojisOptions,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_EMOJIS]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_EMOJIS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_EMOJIS);
   }
@@ -265,7 +265,7 @@ export async function editEmoji(
   id: string,
   options: EditEmojisOptions,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_EMOJIS]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_EMOJIS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_EMOJIS);
   }
@@ -282,7 +282,7 @@ export async function deleteEmoji(
   id: string,
   reason?: string,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_EMOJIS]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_EMOJIS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_EMOJIS);
   }
@@ -304,7 +304,7 @@ export async function createGuildRole(
   options: CreateRoleOptions,
   reason?: string,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_ROLES]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_ROLES"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_ROLES);
   }
@@ -335,7 +335,7 @@ export async function editRole(
   id: string,
   options: CreateRoleOptions,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_ROLES]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_ROLES"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_ROLES);
   }
@@ -350,7 +350,7 @@ export async function editRole(
 
 /** Delete a guild role. Requires the MANAGE_ROLES permission. */
 export async function deleteRole(guildID: string, id: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_ROLES]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_ROLES"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_ROLES);
   }
@@ -363,7 +363,7 @@ export async function deleteRole(guildID: string, id: string) {
 * ⚠️ **If you need this, you are probably doing something wrong. This is not intended for use. Your roles will be cached in your guild.**
 */
 export async function getRoles(guildID: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_ROLES]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_ROLES"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_ROLES);
   }
@@ -373,7 +373,7 @@ export async function getRoles(guildID: string) {
 
 /** Modify the positions of a set of role objects for the guild. Requires the MANAGE_ROLES permission. */
 export async function swapRoles(guildID: string, rolePositons: PositionSwap) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_ROLES]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_ROLES"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_ROLES);
   }
@@ -387,7 +387,7 @@ export async function getPruneCount(guildID: string, options: PruneOptions) {
     throw new Error(Errors.PRUNE_MIN_DAYS);
   }
 
-  const hasPerm = await botHasPermission(guildID, [Permissions.KICK_MEMBERS]);
+  const hasPerm = await botHasPermission(guildID, ["KICK_MEMBERS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_KICK_MEMBERS);
   }
@@ -406,7 +406,7 @@ export async function pruneMembers(guildID: string, options: PruneOptions) {
     throw new Error(Errors.PRUNE_MIN_DAYS);
   }
 
-  const hasPerm = await botHasPermission(guildID, [Permissions.KICK_MEMBERS]);
+  const hasPerm = await botHasPermission(guildID, ["KICK_MEMBERS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_KICK_MEMBERS);
   }
@@ -432,7 +432,7 @@ export async function getAuditLogs(
   guildID: string,
   options: GetAuditLogsOptions,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.VIEW_AUDIT_LOG]);
+  const hasPerm = await botHasPermission(guildID, ["VIEW_AUDIT_LOG"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_VIEW_AUDIT_LOG);
   }
@@ -447,7 +447,7 @@ export async function getAuditLogs(
 
 /** Returns the guild embed object. Requires the MANAGE_GUILD permission. */
 export async function getEmbed(guildID: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
   }
@@ -461,7 +461,7 @@ export async function editEmbed(
   enabled: boolean,
   channelID?: string | null,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
   }
@@ -479,7 +479,7 @@ export function getVanityURL(guildID: string) {
 
 /** Returns a list of integrations for the guild. Requires the MANAGE_GUILD permission. */
 export async function getIntegrations(guildID: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
   }
@@ -493,7 +493,7 @@ export async function editIntegration(
   id: string,
   options: EditIntegrationOptions,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
   }
@@ -506,7 +506,7 @@ export async function editIntegration(
 
 /** Delete the attached integration object for the guild with this id. Requires MANAGE_GUILD permission. */
 export async function deleteIntegration(guildID: string, id: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
   }
@@ -516,7 +516,7 @@ export async function deleteIntegration(guildID: string, id: string) {
 
 /** Sync an integration. Requires the MANAGE_GUILD permission. */
 export async function syncIntegration(guildID: string, id: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
   }
@@ -526,7 +526,7 @@ export async function syncIntegration(guildID: string, id: string) {
 
 /** Returns a list of ban objects for the users banned from this guild. Requires the BAN_MEMBERS permission. */
 export async function getBans(guildID: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.BAN_MEMBERS]);
+  const hasPerm = await botHasPermission(guildID, ["BAN_MEMBERS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_BAN_MEMBERS);
   }
@@ -542,7 +542,7 @@ export async function getBans(guildID: string) {
 
 /** Returns a ban object for the given user or a 404 not found if the ban cannot be found. Requires the BAN_MEMBERS permission. */
 export async function getBan(guildID: string, memberID: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.BAN_MEMBERS]);
+  const hasPerm = await botHasPermission(guildID, ["BAN_MEMBERS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_BAN_MEMBERS);
   }
@@ -554,7 +554,7 @@ export async function getBan(guildID: string, memberID: string) {
 
 /** Ban a user from the guild and optionally delete previous messages sent by the user. Requires the BAN_MEMBERS permission. */
 export async function ban(guildID: string, id: string, options: BanOptions) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.BAN_MEMBERS]);
+  const hasPerm = await botHasPermission(guildID, ["BAN_MEMBERS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_BAN_MEMBERS);
   }
@@ -567,7 +567,7 @@ export async function ban(guildID: string, id: string, options: BanOptions) {
 
 /** Remove the ban for a user. REquires BAN_MEMBERS permission */
 export async function unban(guildID: string, id: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.BAN_MEMBERS]);
+  const hasPerm = await botHasPermission(guildID, ["BAN_MEMBERS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_BAN_MEMBERS);
   }
@@ -576,7 +576,7 @@ export async function unban(guildID: string, id: string) {
 
 /** Modify a guilds settings. Requires the MANAGE_GUILD permission. */
 export async function editGuild(guildID: string, options: GuildEditOptions) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
   }
@@ -598,7 +598,7 @@ export async function editGuild(guildID: string, options: GuildEditOptions) {
 
 /** Get all the invites for this guild. Requires MANAGE_GUILD permission */
 export async function getInvites(guildID: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
   }
@@ -620,7 +620,7 @@ export function getVoiceRegions(guildID: string) {
 export async function getWebhooks(guildID: string) {
   const hasPerm = await botHasPermission(
     guildID,
-    [Permissions.MANAGE_WEBHOOKS],
+    ["MANAGE_WEBHOOKS"],
   );
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_WEBHOOKS);
@@ -688,7 +688,7 @@ export async function createGuildFromTemplate(
  * Requires the `MANAGE_GUILD` permission.
  */
 export async function getGuildTemplates(guildID: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) throw new Error(Errors.MISSING_MANAGE_GUILD);
 
   const templates = await RequestManager.get(
@@ -705,7 +705,7 @@ export async function deleteGuildTemplate(
   guildID: string,
   templateCode: string,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) throw new Error(Errors.MISSING_MANAGE_GUILD);
 
   const deletedTemplate = await RequestManager.delete(
@@ -724,7 +724,7 @@ export async function createGuildTemplate(
   guildID: string,
   data: CreateGuildTemplate,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) throw new Error(Errors.MISSING_MANAGE_GUILD);
 
   if (data.name.length < 1 || data.name.length > 100) {
@@ -750,7 +750,7 @@ export async function createGuildTemplate(
  * Requires the `MANAGE_GUILD` permission.
  */
 export async function syncGuildTemplate(guildID: string, templateCode: string) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) throw new Error(Errors.MISSING_MANAGE_GUILD);
 
   const template = await RequestManager.put(
@@ -768,7 +768,7 @@ export async function editGuildTemplate(
   templateCode: string,
   data: EditGuildTemplate,
 ) {
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_GUILD]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) throw new Error(Errors.MISSING_MANAGE_GUILD);
 
   if (data.name?.length && (data.name.length < 1 || data.name.length > 100)) {

--- a/src/handlers/member.ts
+++ b/src/handlers/member.ts
@@ -7,7 +7,6 @@ import { ImageFormats, ImageSize } from "../types/cdn.ts";
 import { DMChannelCreatePayload, MessageContent } from "../types/channel.ts";
 import { Errors } from "../types/errors.ts";
 import { EditMemberOptions } from "../types/member.ts";
-import { Permissions } from "../types/permission.ts";
 import { formatImageURL } from "../utils/cdn.ts";
 import { endpoints } from "../utils/constants.ts";
 import {
@@ -65,7 +64,7 @@ export async function addRole(
     }
   }
 
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_ROLES]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_ROLES"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_ROLES);
   }
@@ -96,7 +95,7 @@ export async function removeRole(
     }
   }
 
-  const hasPerm = await botHasPermission(guildID, [Permissions.MANAGE_ROLES]);
+  const hasPerm = await botHasPermission(guildID, ["MANAGE_ROLES"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_ROLES);
   }
@@ -142,7 +141,7 @@ export async function kick(guildID: string, memberID: string, reason?: string) {
     throw new Error(Errors.BOTS_HIGHEST_ROLE_TOO_LOW);
   }
 
-  const hasPerm = await botHasPermission(guildID, [Permissions.KICK_MEMBERS]);
+  const hasPerm = await botHasPermission(guildID, ["KICK_MEMBERS"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_KICK_MEMBERS);
   }
@@ -166,7 +165,7 @@ export async function editMember(
 
     const hasManageNickPerm = await botHasPermission(
       guildID,
-      [Permissions.MANAGE_NICKNAMES],
+      ["MANAGE_NICKNAMES"],
     );
     if (!hasManageNickPerm) {
       throw new Error(Errors.MISSING_MANAGE_NICKNAMES);
@@ -175,7 +174,7 @@ export async function editMember(
 
   const hasManageRolesPerm = await botHasPermission(
     guildID,
-    [Permissions.MANAGE_ROLES],
+    ["MANAGE_ROLES"],
   );
   if (
     options.roles &&
@@ -187,7 +186,7 @@ export async function editMember(
   if (options.mute) {
     const hasMuteMembersPerm = await botHasPermission(
       guildID,
-      [Permissions.MUTE_MEMBERS],
+      ["MUTE_MEMBERS"],
     );
     // TODO: This should check if the member is in a voice channel
     if (
@@ -199,7 +198,7 @@ export async function editMember(
 
   const hasDeafenMembersPerm = await botHasPermission(
     guildID,
-    [Permissions.DEAFEN_MEMBERS],
+    ["DEAFEN_MEMBERS"],
   );
   if (
     options.deaf &&

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -8,7 +8,6 @@ import { MessageContent } from "../types/channel.ts";
 import { Errors } from "../types/errors.ts";
 import { UserPayload } from "../types/guild.ts";
 import { MessageCreateOptions } from "../types/message.ts";
-import { Permissions } from "../types/permission.ts";
 import { endpoints } from "../utils/constants.ts";
 import { botHasChannelPermissions } from "../utils/permissions.ts";
 
@@ -40,7 +39,7 @@ export async function deleteMessage(
     // This needs to check the channels permission not the guild permission
     const hasManageMessages = await botHasChannelPermissions(
       message.channelID,
-      [Permissions.MANAGE_MESSAGES],
+      ["MANAGE_MESSAGES"],
     );
     if (
       !hasManageMessages
@@ -61,7 +60,7 @@ export async function deleteMessage(
 export async function pin(channelID: string, messageID: string) {
   const hasManageMessagesPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_MESSAGES],
+    ["MANAGE_MESSAGES"],
   );
   if (
     !hasManageMessagesPerm
@@ -75,7 +74,7 @@ export async function pin(channelID: string, messageID: string) {
 export async function unpin(channelID: string, messageID: string) {
   const hasManageMessagesPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_MESSAGES],
+    ["MANAGE_MESSAGES"],
   );
   if (
     !hasManageMessagesPerm
@@ -95,7 +94,7 @@ export async function addReaction(
 ) {
   const hasAddReactionsPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.ADD_REACTIONS],
+    ["ADD_REACTIONS"],
   );
   if (!hasAddReactionsPerm) {
     throw new Error(Errors.MISSING_ADD_REACTIONS);
@@ -103,7 +102,7 @@ export async function addReaction(
 
   const hasReadMessageHistoryPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.READ_MESSAGE_HISTORY],
+    ["READ_MESSAGE_HISTORY"],
   );
   if (
     !hasReadMessageHistoryPerm
@@ -168,7 +167,7 @@ export async function removeUserReaction(
 ) {
   const hasManageMessagesPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_MESSAGES],
+    ["MANAGE_MESSAGES"],
   );
   if (!hasManageMessagesPerm) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
@@ -188,7 +187,7 @@ export async function removeUserReaction(
 export async function removeAllReactions(channelID: string, messageID: string) {
   const hasManageMessagesPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_MESSAGES],
+    ["MANAGE_MESSAGES"],
   );
   if (
     !hasManageMessagesPerm
@@ -208,7 +207,7 @@ export async function removeReactionEmoji(
 ) {
   const hasManageMessagesPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_MESSAGES],
+    ["MANAGE_MESSAGES"],
   );
   if (
     !hasManageMessagesPerm
@@ -247,7 +246,7 @@ export async function editMessage(
 
   const hasSendMessagesPerm = await botHasChannelPermissions(
     message.channelID,
-    [Permissions.SEND_MESSAGES],
+    ["SEND_MESSAGES"],
   );
   if (
     !hasSendMessagesPerm
@@ -257,7 +256,7 @@ export async function editMessage(
 
   const hasSendTtsMessagesPerm = await botHasChannelPermissions(
     message.channelID,
-    [Permissions.SEND_TTS_MESSAGES],
+    ["SEND_TTS_MESSAGES"],
   );
   if (
     content.tts &&

--- a/src/handlers/webhook.ts
+++ b/src/handlers/webhook.ts
@@ -2,7 +2,6 @@ import { RequestManager } from "../module/requestManager.ts";
 import { structures } from "../structures/mod.ts";
 import { Errors } from "../types/errors.ts";
 import { MessageCreateOptions } from "../types/message.ts";
-import { Permissions } from "../types/permission.ts";
 import {
   ExecuteWebhookOptions,
   WebhookCreateOptions,
@@ -22,7 +21,7 @@ export async function createWebhook(
 ) {
   const hasManageWebhooksPerm = await botHasChannelPermissions(
     channelID,
-    [Permissions.MANAGE_WEBHOOKS],
+    ["MANAGE_WEBHOOKS"],
   );
   if (
     !hasManageWebhooksPerm

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -50,7 +50,7 @@ export function memberHasPermission(
 
 export async function botHasPermission(
   guildID: string,
-  permissions: Permissions[],
+  permissions: Permission[],
 ) {
   const guild = await cacheHandlers.get("guilds", guildID);
   if (!guild) return false;
@@ -74,13 +74,13 @@ export async function botHasPermission(
 
   if (permissionBits & BigInt(Permissions.ADMINISTRATOR)) return true;
 
-  return permissions.every((permission) => permissionBits & BigInt(permission));
+  return permissions.every((permission) => permissionBits & BigInt(Permissions[permission]));
 }
 
 /** Checks if the bot has the permissions in a channel */
 export function botHasChannelPermissions(
   channelID: string,
-  permissions: Permissions[],
+  permissions: Permission[],
 ) {
   return hasChannelPermissions(channelID, botID, permissions);
 }
@@ -89,7 +89,7 @@ export function botHasChannelPermissions(
 export async function hasChannelPermissions(
   channelID: string,
   memberID: string,
-  permissions: Permissions[],
+  permissions: Permission[],
 ) {
   const channel = await cacheHandlers.get("channels", channelID);
   if (!channel) return false;
@@ -121,7 +121,7 @@ export async function hasChannelPermissions(
     if (member.roles.includes(overwrite.id)) rolesOverwrites.push(overwrite);
   }
 
-  const allowedPermissions = new Set<Permissions>();
+  const allowedPermissions = new Set<Permission>();
 
   // Member perms override everything so we must check them first
   if (memberOverwrite) {
@@ -129,12 +129,12 @@ export async function hasChannelPermissions(
     const denyBits = memberOverwrite.deny;
     for (const perm of permissions) {
       // One of the necessary permissions is denied. Since this is main permission we can cancel if its denied.
-      if (BigInt(denyBits) & BigInt(perm)) return false;
+      if (BigInt(denyBits) & BigInt(Permissions[perm])) return false;
       // Already allowed perm
       if (allowedPermissions.has(perm)) continue;
 
       // This perm is allowed so we save it
-      if (BigInt(allowBits) & BigInt(perm)) {
+      if (BigInt(allowBits) & BigInt(Permissions[perm])) {
         allowedPermissions.add(perm);
       }
     }
@@ -148,17 +148,17 @@ export async function hasChannelPermissions(
     for (const overwrite of rolesOverwrites) {
       const allowBits = overwrite.allow;
       // This perm is allowed so we save it
-      if (BigInt(allowBits) & BigInt(perm)) {
+      if (BigInt(allowBits) & BigInt(Permissions[perm])) {
         allowedPermissions.add(perm);
         break;
       }
 
       const denyBits = overwrite.deny;
       // If this role denies it we need to save and check if another role allows it, allows > deny
-      if (BigInt(denyBits) & BigInt(perm)) {
+      if (BigInt(denyBits) & BigInt(Permissions[perm])) {
         // This role denies his perm, but before denying we need to check all other roles if any allow as allow > deny
         const isAllowed = rolesOverwrites.some((o) =>
-          BigInt(o.allow) & BigInt(perm)
+          BigInt(o.allow) & BigInt(Permissions[perm])
         );
         if (isAllowed) continue;
         // This permission is in fact denied. Since Roles overrule everything below here we can cancel ou here
@@ -174,9 +174,9 @@ export async function hasChannelPermissions(
       // Already allowed perm
       if (allowedPermissions.has(perm)) continue;
       // One of the necessary permissions is denied. Since everyone overwrite overrides role perms we can cancel here
-      if (BigInt(denyBits) & BigInt(perm)) return false;
+      if (BigInt(denyBits) & BigInt(Permissions[perm])) return false;
       // This perm is allowed so we save it
-      if (BigInt(allowBits) & BigInt(perm)) {
+      if (BigInt(allowBits) & BigInt(Permissions[perm])) {
         allowedPermissions.add(perm);
       }
     }

--- a/tests/mod.test.ts
+++ b/tests/mod.test.ts
@@ -22,7 +22,6 @@ import {
   editChannel,
 } from "../src/handlers/channel.ts";
 import { getChannel } from "../src/handlers/guild.ts";
-import { Permissions } from "../src/types/permission.ts";
 
 const token = Deno.env.get("DISCORD_TOKEN");
 if (!token) throw "Token is not provided";
@@ -179,13 +178,13 @@ Deno.test({
       data.guildID,
       data.roleID,
       channel.permissionOverwrites,
-      [Permissions.VIEW_CHANNEL, Permissions.SEND_MESSAGES],
+      ["VIEW_CHANNEL", "SEND_MESSAGES"],
     );
     const missingPerm = channelOverwriteHasPermission(
       data.guildID,
       data.roleID,
       channel.permissionOverwrites,
-      [Permissions.USE_EXTERNAL_EMOJIS],
+      ["USE_EXTERNAL_EMOJIS"],
     );
 
     assertEquals(hasPerm, true);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pr changes all Permissions to Permission type allowing users to have 1 form to interact with the lib in a consistant manner and still keeping all th ebenefits. Note this will actually improve it as u no longer need to import the Permissions enum.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
